### PR TITLE
fix broken links to macro names

### DIFF
--- a/conditional-require/conditional-require.scrbl
+++ b/conditional-require/conditional-require.scrbl
@@ -9,21 +9,25 @@
 
 @; =============================================================================
 
-This macro conditionally requires one of two module paths based on a compile-time condition.
+@defmodule[syntax-parse-example/conditional-require/conditional-require]{}
 
-@racketfile{conditional-require.rkt}
+@defform[(conditional-require expr id id)]{
 
-Notes:
-@itemlist[
-@item{
-  The syntax class @racket[mod-name] matches syntactic strings or identifiers.
-  This doesn't guarantee that the second and third argument to @racket[conditional-require]
-   are valid module paths, but it rules out nonsense like @racket[(conditional-require #true (+ 2 2) 91)].
+  This macro conditionally requires one of two module paths based on a compile-time condition.
+
+  @racketfile{conditional-require.rkt}
+
+  Notes:
+  @itemlist[
+  @item{
+    The syntax class @racket[mod-name] matches syntactic strings or identifiers.
+    This doesn't guarantee that the second and third argument to @racket[conditional-require]
+     are valid module paths, but it rules out nonsense like @racket[(conditional-require #true (+ 2 2) 91)].
+  }
+  @item{
+    The test could be more interesting.
+    It could branch on the value of @racket[current-command-line-arguments],
+     or do a @racket[case] based on @racket[system-type].
+  }
+  ]
 }
-@item{
-  The test could be more interesting.
-  It could branch on the value of @racket[current-command-line-arguments],
-   or do a @racket[case] based on @racket[system-type].
-}
-]
-

--- a/cross-macro-communication/cross-macro-communication.scrbl
+++ b/cross-macro-communication/cross-macro-communication.scrbl
@@ -10,41 +10,48 @@
 
 @; =============================================================================
 
-The @racket[define-for-macros] and @racket[get-macroed]
-demonstrate the use of @racket[syntax-local-value] when
-communicating information across macros. Anything defined
-with @racket[define-for-macros] can be accessed (at
-compile/macro expansion time) by @racket[get-macroed].
+@defmodule[syntax-parse-example/cross-macro-communication/cross-macro-communication]{}
 
-@examples[#:eval cross-macro-communication-eval
-          (define-for-macros cake 42)
-          (get-macroed cake)
-          (eval:error cake)
-]
+@deftogether[(
+ @defform[(define-for-macros id expr)]
+ @defform[(get-macroed id)]
+)]{
+  The @racket[define-for-macros] and @racket[get-macroed]
+  demonstrate the use of @racket[syntax-local-value] when
+  communicating information across macros. Anything defined
+  with @racket[define-for-macros] can be accessed (at
+  compile/macro expansion time) by @racket[get-macroed].
 
-This communication works even if the identifiers are defined and used in different files or modules:
+  @examples[#:eval cross-macro-communication-eval
+            (define-for-macros cake 42)
+            (get-macroed cake)
+            (eval:error cake)
+  ]
 
-@examples[#:eval cross-macro-communication-eval
-          (module the-definition racket
-            (require syntax-parse-example/cross-macro-communication/cross-macro-communication)
-            (define-for-macros shake 54)
-            (provide shake))
-          (module the-use racket
-            (require 'the-definition
-                     syntax-parse-example/cross-macro-communication/cross-macro-communication)
-            (get-macroed shake))
-          (require 'the-use)]
+  This communication works even if the identifiers are defined and used in different files or modules:
 
-The following is the source code for @racket[define-for-macros] and @racket[get-macroed]:
+  @examples[#:eval cross-macro-communication-eval
+            (module the-definition racket
+              (require syntax-parse-example/cross-macro-communication/cross-macro-communication)
+              (define-for-macros shake 54)
+              (provide shake))
+            (module the-use racket
+              (require 'the-definition
+                       syntax-parse-example/cross-macro-communication/cross-macro-communication)
+              (get-macroed shake))
+            (require 'the-use)]
 
-@racketfile{cross-macro-communication.rkt}
+  The following is the source code for @racket[define-for-macros] and @racket[get-macroed]:
 
-In @racket[define-for-macros], the macro simply binds a new
-value at compile time using @racket[define-syntax]. In this
-example @racket[define-for-macros] is mostly synonymous with
-@racket[define-syntax], but it demonstrates that the
-@racket[name] could be changed (to say add a question mark
-at the end), and the given expression can be changed. The
-@racket[get-macroed] form simply takes the compile time value and
-puts it in the run time module. If @racket[name] is used
-outside of a macro then a syntax error is raised.
+  @racketfile{cross-macro-communication.rkt}
+
+  In @racket[define-for-macros], the macro simply binds a new
+  value at compile time using @racket[define-syntax]. In this
+  example @racket[define-for-macros] is mostly synonymous with
+  @racket[define-syntax], but it demonstrates that the
+  @racket[name] could be changed (to say add a question mark
+  at the end), and the given expression can be changed. The
+  @racket[get-macroed] form simply takes the compile time value and
+  puts it in the run time module. If @racket[name] is used
+  outside of a macro then a syntax error is raised.
+}

--- a/def/def.scrbl
+++ b/def/def.scrbl
@@ -9,104 +9,111 @@
 
 @; =============================================================================
 
-@examples[#:eval def-eval
- (module snoc racket/base
-   (require syntax-parse-example/def/def)
-   (def (snoc (x* : list?) x)
-     "Append the value `x` to the end of the given list"
-     #:test [
-       ((snoc '(1 2) 3) ==> '(1 2 3))
-       ((snoc '(a b) '(c)) ==> '(a b (c)))]
-     (append x* (list x)))
-   (provide snoc))
- (require 'snoc)
- (eval:error (snoc 1 '(2 3)))
- (snoc '(1 2) 3)
-]
+@defmodule[syntax-parse-example/def/def]{}
 
-The @racket[def] macro is similar to @racket[define] but:
-@itemlist[
-@item{
-  requires a docstring
-}
-@item{
-  requires test cases;
-}
-@item{
-  optionally accepts contract annotations on its arguments; and
-}
-@item{
-  optionally accepts pre- and post- conditions.
-}
-]
+@defform[(def (id arg-spec ...)
+           doc-contract-tests ...
+           expr ...)]{
 
-@examples[#:eval def-eval
-  (module gcd racket/base
-    (require syntax-parse-example/def/def)
-    (def (gcd (x : integer?) (y : integer?))
-      "greatest common divisor"
-      #:pre [
-        (>= "First argument must be greater-or-equal than second")]
-      #:test [
-        ((gcd 10 3) ==> 1)
-        ((gcd 12 3) ==> 3)]
-      (cond
-       [(zero? y) x]
-       [else (gcd y (- x (* y (quotient x y))))]))
-     (provide gcd))
-  (require 'gcd)
-  (eval:error (gcd 42 777))
-  (gcd 777 42)
-]
+  @examples[#:eval def-eval
+   (module snoc racket/base
+     (require syntax-parse-example/def/def)
+     (def (snoc (x* : list?) x)
+       "Append the value `x` to the end of the given list"
+       #:test [
+         ((snoc '(1 2) 3) ==> '(1 2 3))
+         ((snoc '(a b) '(c)) ==> '(a b (c)))]
+       (append x* (list x)))
+     (provide snoc))
+   (require 'snoc)
+   (eval:error (snoc 1 '(2 3)))
+   (snoc '(1 2) 3)
+  ]
 
-If the docstring or test cases are missing, @racket[def] throws a syntax error.
+  The @racket[def] macro is similar to @racket[define] but:
+  @itemlist[
+  @item{
+    requires a docstring
+  }
+  @item{
+    requires test cases;
+  }
+  @item{
+    optionally accepts contract annotations on its arguments; and
+  }
+  @item{
+    optionally accepts pre- and post- conditions.
+  }
+  ]
 
-@examples[#:eval def-eval
-  (eval:error (def (f x)
-                x))
-  (eval:error (def (f x)
-                "identity"
-                x))
-  (eval:error (def (f x)
-                #:test [((f 1) ==> 1)]
-                x))
-]
+  @examples[#:eval def-eval
+    (module gcd racket/base
+      (require syntax-parse-example/def/def)
+      (def (gcd (x : integer?) (y : integer?))
+        "greatest common divisor"
+        #:pre [
+          (>= "First argument must be greater-or-equal than second")]
+        #:test [
+          ((gcd 10 3) ==> 1)
+          ((gcd 12 3) ==> 3)]
+        (cond
+         [(zero? y) x]
+         [else (gcd y (- x (* y (quotient x y))))]))
+       (provide gcd))
+    (require 'gcd)
+    (eval:error (gcd 42 777))
+    (gcd 777 42)
+  ]
 
-How to read the macro:
-@itemlist[#:style 'ordered
-@item{
-  The @racket[begin-for-syntax] defines two syntax classes (see @secref["Syntax_Classes" #:doc '(lib "syntax/scribblings/syntax.scrbl")]).
-  The first syntax class, @racket[arg-spec], captures arguments with an optional contract annotation.
-  The second, @racket[doc-spec], captures docstrings.
-}
-@item{
-  The large @racket[~or] pattern captures the required-and-optional stuff that
-   @racket[def] accepts---in particular, the docstring, the @racket[#:test] test cases,
-   the @racket[#:pre] pre-conditions, and the @racket[#:post] post-conditions.
-}
-@item{
-  The four @racket[#:with] clauses build syntax objects that run unit tests
-   and/or checks.
-}
-]
+  If the docstring or test cases are missing, @racket[def] throws a syntax error.
 
-The @racket[def] macro:
+  @examples[#:eval def-eval
+    (eval:error (def (f x)
+                  x))
+    (eval:error (def (f x)
+                  "identity"
+                  x))
+    (eval:error (def (f x)
+                  #:test [((f 1) ==> 1)]
+                  x))
+  ]
 
-@racketfile{def.rkt}
+  How to read the macro:
+  @itemlist[#:style 'ordered
+  @item{
+    The @racket[begin-for-syntax] defines two syntax classes (see @secref["Syntax_Classes" #:doc '(lib "syntax/scribblings/syntax.scrbl")]).
+    The first syntax class, @racket[arg-spec], captures arguments with an optional contract annotation.
+    The second, @racket[doc-spec], captures docstrings.
+  }
+  @item{
+    The large @racket[~or] pattern captures the required-and-optional stuff that
+     @racket[def] accepts---in particular, the docstring, the @racket[#:test] test cases,
+     the @racket[#:pre] pre-conditions, and the @racket[#:post] post-conditions.
+  }
+  @item{
+    The four @racket[#:with] clauses build syntax objects that run unit tests
+     and/or checks.
+  }
+  ]
 
-Notes:
-@itemlist[
-@item{
-  This macro gives poor error messages when the docstring or test
-   cases are missing.
+  The @racket[def] macro:
+
+  @racketfile{def.rkt}
+
+  Notes:
+  @itemlist[
+  @item{
+    This macro gives poor error messages when the docstring or test
+     cases are missing.
+  }
+  @item{
+    The @racket[doc-spec] syntax class could be extended to accept Scribble, or
+     another kind of docstring syntax.
+  }
+  @item{
+    A @racket[#:test] case may optionally use the @racket[#:stdout] keyword.
+    If given, the test will fail unless running the test prints the same string
+     to @racket[current-output-port].
+  }
+  ]
 }
-@item{
-  The @racket[doc-spec] syntax class could be extended to accept Scribble, or
-   another kind of docstring syntax.
-}
-@item{
-  A @racket[#:test] case may optionally use the @racket[#:stdout] keyword.
-  If given, the test will fail unless running the test prints the same string
-   to @racket[current-output-port].
-}
-]

--- a/define-datum-literal-set/define-datum-literal-set.scrbl
+++ b/define-datum-literal-set/define-datum-literal-set.scrbl
@@ -9,28 +9,33 @@
 
 @; =============================================================================
 
-@racket[syntax-parse] can match literal symbols using the @racket[#:datum-literals]
- option or the @racket[~datum] pattern form.
-These work well for a small number of literals.
+@defmodule[syntax-parse-example/define-datum-literal-set/define-datum-literal-set]{}
 
-Given a sequence of symbols, the @racket[define-datum-literal-set] macro builds
- a @tech[#:doc '(lib "syntax/scribblings/syntax.scrbl")]{syntax class} that matches these symbols.
+@defform[(define-datum-literal-set id (id ...))]{
 
-@racketblock[
- (define-datum-literal-set C-keyword
-   (auto break case char const continue default do double else))
+  @racket[syntax-parse] can match literal symbols using the @racket[#:datum-literals]
+   option or the @racket[~datum] pattern form.
+  These work well for a small number of literals.
 
- (define-syntax (is-C-keyword? stx)
-   (syntax-parse stx
-    [(_ x:C-keyword)
-     #'#true]
-    [(_ x)
-     #'#false]))
+  Given a sequence of symbols, the @racket[define-datum-literal-set] macro builds
+   a @tech[#:doc '(lib "syntax/scribblings/syntax.scrbl")]{syntax class} that matches these symbols.
 
- (is-C-keyword? else)
- (is-C-keyword? synchronized)
-]
+  @racketblock[
+   (define-datum-literal-set C-keyword
+     (auto break case char const continue default do double else))
 
-The macro works by defining a @tech[#:doc '(lib "syntax/scribblings/syntax.scrbl")]{literal set} and then a @tech[#:doc '(lib "syntax/scribblings/syntax.scrbl")]{syntax class}.
+   (define-syntax (is-C-keyword? stx)
+     (syntax-parse stx
+      [(_ x:C-keyword)
+       #'#true]
+      [(_ x)
+       #'#false]))
 
-@racketfile{define-datum-literal-set.rkt}
+   (is-C-keyword? else)
+   (is-C-keyword? synchronized)
+  ]
+
+  The macro works by defining a @tech[#:doc '(lib "syntax/scribblings/syntax.scrbl")]{literal set} and then a @tech[#:doc '(lib "syntax/scribblings/syntax.scrbl")]{syntax class}.
+
+  @racketfile{define-datum-literal-set.rkt}
+}

--- a/first-class-or/first-class-or.scrbl
+++ b/first-class-or/first-class-or.scrbl
@@ -1,57 +1,63 @@
 #lang syntax-parse-example
 @require[
   (for-label
+    racket/base
+    syntax/parse
     syntax-parse-example/first-class-or/first-class-or)]
 
-@;@(define first-class-or-eval
-@;   (make-base-eval
-@;     '(require syntax-parse-example/first-class-or/first-class-or)))
+@(define first-class-or-eval
+   (make-base-eval
+     '(require syntax-parse-example/first-class-or/first-class-or)))
 
 @title{@tt{first-class-or}}
-@;@defmodule[syntax-parse-example/first-class-or/first-class-or]{}
+
 @; =============================================================================
 
-Racket's @racket[or] is a macro, not a function.
-It cannot be used like a normal value (i.e., evaluated as an identifier).
-@margin-note{See also @secref["and+or" #:doc '(lib "scribblings/guide/guide.scrbl")]}
+@defmodule[syntax-parse-example/first-class-or/first-class-or]{}
 
-@;@examples[#:eval (make-base-eval)
-@;  (or #false #true)
-@;  (eval:error (apply or '(#false #true 0)))
-@;]
-@;
-@;@tech/guide{Identifier macros} can be evaluated as identifiers.
-So we can write a @racket[first-class-or] macro to:
-@;@itemlist[
-@;@item{
-@;  expand like Racket's @racket[or] when called like a function, and
-@;}
-@;@item{
-@;  expand to a function definition when used like an identifier.
-@;}
-@;]
-@;In the latter case, the function that @racket[first-class-or] evaluates to
-@; is similar to @racket[or], but evaluates all its arguments.
-@;
-@;@examples[#:eval first-class-or-eval
-@;  (first-class-or #false #true)
-@;  (apply first-class-or '(#false #true 0))
-@;  (first-class-or (+ 2 3) (let loop () (loop)))
-@;  (map first-class-or '(9 #false 3) '(8 #false #false))
-@;]
-@;
-@;The macro:
-@;
-@;@racketfile{first-class-or.rkt}
-@;
-@;Some comments:
-@;@itemlist[
-@;@item{
-@;  The first two @racket[syntax/parse] clauses define what happens when @racket[or]
-@;   is called like a function.
-@;}
-@;@item{
-@;  The pattern @litchar{_:id} matches any @tech/reference{identifier}.
-@;}
-@;]
-@;
+@defform[(first-class-or expr ...)]{
+  Racket's @racket[or] is a macro, not a function.
+  It cannot be used like a normal value (i.e., evaluated as an identifier).
+  @margin-note{See also @secref["and+or" #:doc '(lib "scribblings/guide/guide.scrbl")]}
+
+  @examples[#:eval (make-base-eval)
+    (or #false #true)
+    (eval:error (apply or '(#false #true 0)))
+  ]
+
+  @tech/guide{Identifier macros} can be evaluated as identifiers.
+
+  So we can write a @racket[first-class-or] macro to:
+  @itemlist[
+  @item{
+    expand like Racket's @racket[or] when called like a function, and
+  }
+  @item{
+    expand to a function definition when used like an identifier.
+  }
+  ]
+  In the latter case, the function that @racket[first-class-or] evaluates to
+   is similar to @racket[or], but evaluates all its arguments.
+
+  @examples[#:eval first-class-or-eval
+    (first-class-or #false #true)
+    (apply first-class-or '(#false #true 0))
+    (first-class-or (+ 2 3) (let loop () (loop)))
+    (map first-class-or '(9 #false 3) '(8 #false #false))
+  ]
+
+  The macro:
+
+  @racketfile{first-class-or.rkt}
+
+  Some comments:
+  @itemlist[
+  @item{
+    The first two @racket[syntax/parse] clauses define what happens when @racket[or]
+     is called like a function.
+  }
+  @item{
+    The pattern @litchar{_:id} matches any @tech/reference{identifier}.
+  }
+  ]
+}

--- a/first-class-or/first-class-or.scrbl
+++ b/first-class-or/first-class-or.scrbl
@@ -1,58 +1,57 @@
 #lang syntax-parse-example
 @require[
   (for-label
-    racket/base
-    syntax/parse
     syntax-parse-example/first-class-or/first-class-or)]
 
-@(define first-class-or-eval
-   (make-base-eval
-     '(require syntax-parse-example/first-class-or/first-class-or)))
+@;@(define first-class-or-eval
+@;   (make-base-eval
+@;     '(require syntax-parse-example/first-class-or/first-class-or)))
 
 @title{@tt{first-class-or}}
+@;@defmodule[syntax-parse-example/first-class-or/first-class-or]{}
 @; =============================================================================
 
 Racket's @racket[or] is a macro, not a function.
 It cannot be used like a normal value (i.e., evaluated as an identifier).
 @margin-note{See also @secref["and+or" #:doc '(lib "scribblings/guide/guide.scrbl")]}
 
-@examples[#:eval (make-base-eval)
-  (or #false #true)
-  (eval:error (apply or '(#false #true 0)))
-]
-
-@tech/guide{Identifier macros} can be evaluated as identifiers.
+@;@examples[#:eval (make-base-eval)
+@;  (or #false #true)
+@;  (eval:error (apply or '(#false #true 0)))
+@;]
+@;
+@;@tech/guide{Identifier macros} can be evaluated as identifiers.
 So we can write a @racket[first-class-or] macro to:
-@itemlist[
-@item{
-  expand like Racket's @racket[or] when called like a function, and
-}
-@item{
-  expand to a function definition when used like an identifier.
-}
-]
-In the latter case, the function that @racket[first-class-or] evaluates to
- is similar to @racket[or], but evaluates all its arguments.
-
-@examples[#:eval first-class-or-eval
-  (first-class-or #false #true)
-  (apply first-class-or '(#false #true 0))
-  (first-class-or (+ 2 3) (let loop () (loop)))
-  (map first-class-or '(9 #false 3) '(8 #false #false))
-]
-
-The macro:
-
-@racketfile{first-class-or.rkt}
-
-Some comments:
-@itemlist[
-@item{
-  The first two @racket[syntax/parse] clauses define what happens when @racket[or]
-   is called like a function.
-}
-@item{
-  The pattern @litchar{_:id} matches any @tech/reference{identifier}.
-}
-]
-
+@;@itemlist[
+@;@item{
+@;  expand like Racket's @racket[or] when called like a function, and
+@;}
+@;@item{
+@;  expand to a function definition when used like an identifier.
+@;}
+@;]
+@;In the latter case, the function that @racket[first-class-or] evaluates to
+@; is similar to @racket[or], but evaluates all its arguments.
+@;
+@;@examples[#:eval first-class-or-eval
+@;  (first-class-or #false #true)
+@;  (apply first-class-or '(#false #true 0))
+@;  (first-class-or (+ 2 3) (let loop () (loop)))
+@;  (map first-class-or '(9 #false 3) '(8 #false #false))
+@;]
+@;
+@;The macro:
+@;
+@;@racketfile{first-class-or.rkt}
+@;
+@;Some comments:
+@;@itemlist[
+@;@item{
+@;  The first two @racket[syntax/parse] clauses define what happens when @racket[or]
+@;   is called like a function.
+@;}
+@;@item{
+@;  The pattern @litchar{_:id} matches any @tech/reference{identifier}.
+@;}
+@;]
+@;

--- a/let-star/let-star.scrbl
+++ b/let-star/let-star.scrbl
@@ -9,45 +9,50 @@
 
 @; =============================================================================
 
-Racket's @racket[let] binds identifiers simultaneously;
- Racket's @racket[let*] binds identifiers in sequence.
-For example:
+@defmodule[syntax-parse-example/let-star/let-star]{}
 
-@racketblock[
-  (let* ([a 1]
-         [b (+ a 1)])
-    b)]
+@defform[(let-star ((id expr) ...) expr)]{
 
-behaves the same as a nested @racket[let]:
+  Racket's @racket[let] binds identifiers simultaneously;
+   Racket's @racket[let*] binds identifiers in sequence.
+  For example:
 
-@racketblock[
-  (let ([a 1])
-    (let ([b (+ a 1)])
-      b))]
+  @racketblock[
+    (let* ([a 1]
+           [b (+ a 1)])
+      b)]
 
-The @racket[let-star] macro implements @racket[let*] in terms of @racket[let].
+  behaves the same as a nested @racket[let]:
 
-@racketfile{let-star.rkt}
+  @racketblock[
+    (let ([a 1])
+      (let ([b (+ a 1)])
+        b))]
 
-Note:
-@itemlist[
-@item{
-  The macro is recursive.
-  The use of @racket[let-star] in the second clause will later expand to
-   a sequence of @racket[let]s.
+  The @racket[let-star] macro implements @racket[let*] in terms of @racket[let].
+
+  @racketfile{let-star.rkt}
+
+  Note:
+  @itemlist[
+  @item{
+    The macro is recursive.
+    The use of @racket[let-star] in the second clause will later expand to
+     a sequence of @racket[let]s.
+  }
+  @item{
+    The pattern @racket[...+] matches one or more of the previous pattern.
+  }
+  ]
+
+  @examples[#:eval let-star-eval
+   (eval:error (let* 1))
+
+   (eval:error (let* ([a 1])))
+
+   (let* ([a 1]
+          [b (+ a 1)]
+          [c (+ b 1)])
+     c)
+  ]
 }
-@item{
-  The pattern @racket[...+] matches one or more of the previous pattern.
-}
-]
-
-@examples[#:eval let-star-eval
- (eval:error (let* 1))
-
- (eval:error (let* ([a 1])))
-
- (let* ([a 1]
-        [b (+ a 1)]
-        [c (+ b 1)])
-   c)
-]

--- a/multi-check-true/multi-check-true.scrbl
+++ b/multi-check-true/multi-check-true.scrbl
@@ -9,26 +9,30 @@
 
 @; =============================================================================
 
-The @tt{multi-check-true} expands into a sequence of @racket[check-true] unit tests.
-For example:
+@defmodule[syntax-parse-example/multi-check-true/multi-check-true]{}
 
-@racketblock[
-  (multi-check-true
-    #true
-    #false
-    (even? 0))]
+@defform[(multi-check-true expr ...)]{
 
-expands to code that behaves the same as:
+  The @tt{multi-check-true} expands into a sequence of @racket[check-true] unit tests.
+  For example:
 
-@racketblock[
-  (check-true #true)
-  (check-true #false)
-  (check-true (even? 0))]
+  @racketblock[
+    (multi-check-true
+      #true
+      #false
+      (even? 0))]
 
-The main difference between the macro and the example is that the macro uses
- @racket[with-check-info*] to improve test failure messages.
-If part of a @racket[multi-check-true] fails, the error message points
- to the bad expression (rather than the @racket[multi-check-true] macro).
+  expands to code that behaves the same as:
 
-@racketfile{multi-check-true.rkt}
+  @racketblock[
+    (check-true #true)
+    (check-true #false)
+    (check-true (even? 0))]
 
+  The main difference between the macro and the example is that the macro uses
+   @racket[with-check-info*] to improve test failure messages.
+  If part of a @racket[multi-check-true] fails, the error message points
+   to the bad expression (rather than the @racket[multi-check-true] macro).
+
+  @racketfile{multi-check-true.rkt}
+}

--- a/raco.rkt
+++ b/raco.rkt
@@ -46,32 +46,36 @@
     ""
     (format "(define-syntax (~a stx)" name)
     (format "  (syntax-parse stx")
-    (format "   [x x])) ;; TODO fill in here")))
+    (format "   [x #'(void)])) ;; TODO fill in here")))
 
 
 (define (make-example-doc! dir name)
+  (define mod-name (format "syntax-parse-example/~a/~a" name name))
   (displayln* (path-replace-extension (build-path dir name) #".scrbl")
     "#lang syntax-parse-example"
     "@require["
-    (format "  (for-label racket/base syntax/parse syntax-parse-example/~a/~a)]" name name)
+    (format "  (for-label racket/base syntax/parse ~a)]" mod-name)
     ""
     (format "@(define ~a-eval" name)
-    (format "   (make-base-eval '(require syntax-parse-example/~a/~a)))" name name)
+    (format "   (make-base-eval '(require ~a)))" mod-name)
     ""
     (format "@title{@tt{~a}}" name)
     ""
     "@; ============================================================================="
     ""
-    "@; TODO add intro text here"
+    (format "@defmodule[~a]{}" mod-name)
     ""
-    (format "@examples[#:eval ~a-eval" name)
-    " @; TODO add examples here"
-    "]"
+    (format "@defform[(~a expr ...)]{" name)
+    "  @; TODO add intro text here"
     ""
-    (format "@racketfile{~a.rkt}" name)
+    (format "  @examples[#:eval ~a-eval" name)
+    "   @; TODO add examples here"
+    "  ]"
     ""
-    "@; TODO add description here"
+    (format "  @racketfile{~a.rkt}" name)
     ""
+    "  @; TODO add description here"
+    "}"
     ))
 
 (define (make-example-test! dir name)

--- a/rec-contract/rec-contract.scrbl
+++ b/rec-contract/rec-contract.scrbl
@@ -1,6 +1,6 @@
 #lang syntax-parse-example
 @require[
-  (for-label racket/base syntax/parse syntax-parse-example/rec-contract/rec-contract)]
+  (for-label racket/base syntax/parse racket/contract syntax-parse-example/rec-contract/rec-contract)]
 
 @(define rec-contract-eval
    (make-base-eval '(require racket/contract syntax-parse-example/rec-contract/rec-contract)))
@@ -9,19 +9,22 @@
 
 @; =============================================================================
 
-The @racket[rec/c] macro uses Racket's @racket[recursive-contract] form
- to create anonymous recursive contracts.
+@defmodule[syntax-parse-example/rec-contract/rec-contract]{}
 
-@racketfile{rec-contract.rkt}
+@defform[(rec/c id expr)]{
 
-@examples[#:eval rec-contract-eval
-  (define/contract (deep n)
-    (-> integer? (rec/c t (or/c integer? (list/c t))))
-    (if (zero? n)
-      n
-      (list (deep (- n 1)))))
+  The @racket[rec/c] macro uses Racket's @racket[recursive-contract] form
+   to create anonymous recursive contracts.
 
-  (deep 4)
-]
+  @racketfile{rec-contract.rkt}
 
+  @examples[#:eval rec-contract-eval
+    (define/contract (deep n)
+      (-> integer? (rec/c t (or/c integer? (list/c t))))
+      (if (zero? n)
+        n
+        (list (deep (- n 1)))))
 
+    (deep 4)
+  ]
+}

--- a/render.rkt
+++ b/render.rkt
@@ -5,6 +5,8 @@
 (provide
   (except-out
     (all-from-out scribble/doclang scribble/example scribble/manual) #%module-begin)
+  (for-syntax
+    (all-from-out racket/base syntax/parse))
 
   (rename-out [module-begin #%module-begin])
 


### PR DESCRIPTION
Every reference to every example macro used to be a broken link.

Added `defform`s to the examples to fix the links. No more red underline!