### PR TITLE
add struct-list macro

### DIFF
--- a/index.scrbl
+++ b/index.scrbl
@@ -24,3 +24,4 @@
 @include-example{multi-check-true}
 @include-example{define-datum-literal-set}
 @include-example{rec-contract}
+@include-example{struct-list}

--- a/info.rkt
+++ b/info.rkt
@@ -1,7 +1,7 @@
 #lang info
 (define collection "syntax-parse-example")
-(define deps '("at-exp-lib" "base" "scribble-lib" "rackunit-lib"))
-(define build-deps '("scribble-lib" "racket-doc" "rackunit-doc" "rackunit-lib" "scribble-doc"))
+(define deps '("at-exp-lib" "base" "scribble-lib" "rackunit-lib" "typed-racket-lib"))
+(define build-deps '("scribble-lib" "racket-doc" "rackunit-doc" "rackunit-lib" "scribble-doc" "rackunit-typed" "typed-racket-doc"))
 (define pkg-desc "Examples of syntax/parse")
 (define version "0.0")
 (define pkg-authors '(ben))

--- a/struct-list/struct-list-test.rkt
+++ b/struct-list/struct-list-test.rkt
@@ -1,0 +1,43 @@
+#lang typed/racket/base
+(module+ test
+  (require typed/rackunit
+           (rename-in syntax-parse-example/struct-list/struct-list
+                      [struct-list struct]))
+
+  ;; Looks like a struct, but everything's made of lists
+  (struct posn ([x : Real]
+                [y : Real])
+               #:type-name Posn)
+  (struct block ([x : Real]
+                 [y : Real]
+                 [color : Symbol])
+               #:type-name Block)
+  (struct tetra ([center : Posn]
+                 [blocks : (Listof Block)])
+               #:type-name Tetra)
+
+  (: posn=? (-> Posn Posn Boolean))
+  (define (posn=? p1 p2)
+    (and (= (posn-x p1) (posn-x p2))
+         (= (posn-y p1) (posn-y p2))))
+
+  (define origin (posn 0 0))
+  (define line
+    (tetra origin
+           (for/list : (Listof Block)
+                     ([y (in-list '(0 1 2 3))])
+             (block 0 y 'blue))))
+
+  (check-pred posn? origin)
+  (check-pred tetra? line)
+  (check-equal? (posn-x origin) (posn-y origin))
+  (check-equal? 0 (apply + (map block-x (tetra-blocks line))))
+
+
+  ;; Test internal representation
+  (check-pred list? origin)
+  (check-pred list? line)
+  (check-equal? (cadr origin) (cadr origin))
+  (check-equal? origin (tetra-center line))
+
+)

--- a/struct-list/struct-list.rkt
+++ b/struct-list/struct-list.rkt
@@ -1,0 +1,22 @@
+#lang typed/racket/base
+(provide struct-list)
+(require (for-syntax racket/base racket/syntax syntax/parse))
+
+(define-syntax (struct-list stx)
+  (syntax-parse stx #:datum-literals (:)
+   [(_ name:id ([f*:id : t*] ...) #:type-name Name)
+    #:with name? (format-id stx "~a?" (syntax-e #'name))
+    #:with ((name-f* i*) ...)
+      (for/list ([f (in-list (syntax-e #'(f* ...)))]
+                 [i (in-naturals 1)])
+        (list (format-id stx "~a-~a" (syntax-e #'name) (syntax-e f)) i))
+    (syntax/loc stx
+      (begin
+        (define-type Name (Pairof 'name (Listof Any)))
+        (define (name (f* : t*) ...) : Name
+          (list 'name f* ...))
+        (define (name? (v : Any)) : Boolean
+          (and (list? v) (not (null? v)) (eq? 'name (car v))))
+        (define (name-f* (p : Name)) : t*
+          (cast (list-ref p 'i*) t*))
+        ...))]))

--- a/struct-list/struct-list.scrbl
+++ b/struct-list/struct-list.scrbl
@@ -1,0 +1,41 @@
+#lang syntax-parse-example
+@require[
+  (for-label typed/racket/base racket/syntax syntax/parse syntax-parse-example/struct-list/struct-list)]
+
+@(define struct-list-eval
+   (make-base-eval #:lang 'typed/racket/base '(require syntax-parse-example/struct-list/struct-list)))
+
+@title{@tt{struct-list}}
+
+@; =============================================================================
+
+@defmodule[syntax-parse-example/struct-list/struct-list]{}
+
+@defform[(struct-list expr ...)]{
+  The @racket[struct-list] macro has similar syntax as Typed Racket's @racket[struct] form, but creates a new datatype backed by a @racket[list] instead of an actual struct.
+  The only cosmetic difference is that type @racket[#:type-name] keyword is required, and must supply a name that is different from the struct name.
+
+  @examples[#:eval struct-list-eval
+   (struct-list foo ([a : String] [b : String]) #:type-name Foo)
+   (define f (foo "hello" "world"))
+   (foo? f)
+   (string-append (foo-a f) " " (foo-b f))
+   (ann f Foo)
+  ]
+
+  The implementation:
+  @itemlist[#:style 'ordered
+    @item{
+      extracts the names and type names from the syntax,
+    }
+    @item{
+      creates an identifier for the predicate and a sequence of identifiers for the accessors (see the @racket[#:with] clauses),
+    }
+    @item{
+      and defines a constructor and predicate and accessor(s).
+    }
+  ]
+
+  @racketfile{struct-list.rkt}
+
+}


### PR DESCRIPTION
Closes #11 

two weird things:

- no struct-out
- the type is better as (Pair X (Listof Any)) than (Pair X (List T ...)),
  I forget exactly why its better on the left, but the TR examples
  definitely look better that way